### PR TITLE
Raise grpcio versions for python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyln-client>=23.2
 pyln-testing>=24.5
-grpcio
-grpcio-tools<=1.59.0
-grpcio-status<=1.59.0
+grpcio<1.70.0
+grpcio-tools<1.70.0
+grpcio-status<1.70.0
 googleapis-common-protos


### PR DESCRIPTION
The `grpcio*` dependencies currently stated on master can't be installed on python 3.13 